### PR TITLE
Fix, always copy (new) plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode
 nsis/nsis/
 nsis/ps_modules/
+/.vs

--- a/nsis/nsis.ps1
+++ b/nsis/nsis.ps1
@@ -26,25 +26,25 @@ if(!(Test-Path $destination)){
 
 	$directories = Get-ChildItem -Path $destination
 	$nsis3Directory = $directories[0].FullName
-
-	if($includeMorePlugins -eq "yes")
-	{
-		$pluginPath = $path + "\plugins\*"
-		$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
-		Copy-Item $pluginPath $pluginOutput -force
-    }
-    
-	if(-Not ([string]::IsNullOrEmpty($includeCustomPluginsPath)))
-	{
-		$pluginPath = $includeCustomPluginsPath + "\*"
-		$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
-		Copy-Item $pluginPath $pluginOutput -force
-	}
     
     Write-Output "Time taken (Unzip): $((Get-Date).Subtract($start_time).Seconds) second(s)"
 } else {
 	$directories = Get-ChildItem -Path $destination
 	$nsis3Directory = $directories[0].FullName
+}
+
+if($includeMorePlugins -eq "yes")
+{
+	$pluginPath = $path + "\plugins\*"
+	$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
+	Copy-Item $pluginPath $pluginOutput -force
+}
+    
+if(-Not ([string]::IsNullOrEmpty($includeCustomPluginsPath)))
+{
+	$pluginPath = $includeCustomPluginsPath + "\*"
+	$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
+	Copy-Item $pluginPath $pluginOutput -force
 }
 
 $nsis3Exe = $nsis3Directory + "\makensis.exe"

--- a/nsis/nsis.ps1
+++ b/nsis/nsis.ps1
@@ -5,8 +5,7 @@ $includeMorePlugins = Get-VstsInput -Name includeMorePlugins -Require;
 $includeCustomPluginsPath = Get-VstsInput -Name includeCustomPluginsPath -Require;
 
 
-foreach($key in $PSBoundParameters.Keys)
-{
+foreach ($key in $PSBoundParameters.Keys) {
     Write-Host ($key + ' = ' + $PSBoundParameters[$key])
 }
 
@@ -16,35 +15,34 @@ $output = $path + "\nsis.zip"
 
 $destination = $path + "\nsis"
 
-if(!(Test-Path $destination)){
+if (!(Test-Path $destination)) {
 
     $start_time = Get-Date
 
-	Add-Type -assembly "system.io.compression.filesystem"
+    Add-Type -assembly "system.io.compression.filesystem"
 
-	[io.compression.zipfile]::ExtractToDirectory($output, $destination)
+    [io.compression.zipfile]::ExtractToDirectory($output, $destination)
 
-	$directories = Get-ChildItem -Path $destination
-	$nsis3Directory = $directories[0].FullName
+    $directories = Get-ChildItem -Path $destination
+    $nsis3Directory = $directories[0].FullName
     
     Write-Output "Time taken (Unzip): $((Get-Date).Subtract($start_time).Seconds) second(s)"
-} else {
-	$directories = Get-ChildItem -Path $destination
-	$nsis3Directory = $directories[0].FullName
+}
+else {
+    $directories = Get-ChildItem -Path $destination
+    $nsis3Directory = $directories[0].FullName
 }
 
-if($includeMorePlugins -eq "yes")
-{
-	$pluginPath = $path + "\plugins\*"
-	$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
-	Copy-Item $pluginPath $pluginOutput -force
+if ($includeMorePlugins -eq "yes") {
+    $pluginPath = $path + "\plugins\*"
+    $pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
+    Copy-Item $pluginPath $pluginOutput -force
 }
     
-if(-Not ([string]::IsNullOrEmpty($includeCustomPluginsPath)))
-{
-	$pluginPath = $includeCustomPluginsPath + "\*"
-	$pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
-	Copy-Item $pluginPath $pluginOutput -force
+if (-Not ([string]::IsNullOrEmpty($includeCustomPluginsPath))) {
+    $pluginPath = $includeCustomPluginsPath + "\*"
+    $pluginOutput = $nsis3Directory + "\plugins\x86-ansi"
+    Copy-Item $pluginPath $pluginOutput -force
 }
 
 $nsis3Exe = $nsis3Directory + "\makensis.exe"
@@ -52,17 +50,14 @@ $nsis3Exe = $nsis3Directory + "\makensis.exe"
 $env:NSIS_EXE = $nsis3Exe
 Write-Host("##vso[task.setvariable variable=NSIS_EXE;]$nsis3Exe")
 
-if($justInclude -eq "no")
-{
-	$args = ''
+if ($justInclude -eq "no") {
+    $args = ''
 
-    if($arguments -notcontains "/V"){
-        if($env:Debug -eq "true")
-        {
+    if ($arguments -notcontains "/V") {
+        if ($env:Debug -eq "true") {
             $args += "/V4 "
         }
-        if($env:Debug -eq "false")
-        {
+        if ($env:Debug -eq "false") {
             $args += "/V1 "
         }
     }
@@ -72,7 +67,6 @@ if($justInclude -eq "no")
 
     Invoke-VstsTool -FileName $nsis3Exe -Arguments $args -RequireExitCodeZero
 }
-else
-{
+else {
     Write-Host("Including nsis in variable NSIS_EXE: $nsis3Exe")
 }

--- a/nsis/task.json
+++ b/nsis/task.json
@@ -9,7 +9,7 @@
     "version": {
         "Major": 1,
         "Minor": 1,
-        "Patch": 7
+        "Patch": 8
     },
     "links": {
         "home": {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "nsis-task",
     "name": "Nsis Build Task",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "publisher": "bizeta",
     "public": true,
     "icons": {


### PR DESCRIPTION
If the task allready executed once, the second time no new plugins will be copied because the path already exists. So this fix will always force copy the extra plugins folder, and the custom plugins folder.